### PR TITLE
Add Windows support

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,3 +5,4 @@
 
 Google Inc.
 Alexandre Ardhuin <alexandre.ardhuin@gmail.com>
+Oliver Sand <oliver.sand@tentaclelabs.com>

--- a/bin/run_tests.dart
+++ b/bin/run_tests.dart
@@ -187,10 +187,12 @@ runTests(
           if (result.testOutput.trim() != ""
               || result.testErrorOutput.trim() != "") {
             print(result.testOutput.trim()
+            .replaceAll("\r", "")
             .replaceAll(new RegExp(r"^"), "│ ")
             .replaceAll("\n", "\n│ "));
             if (result.testErrorOutput.trim() != "")
               print(result.testErrorOutput.trim()
+              .replaceAll("\r", "")
               .replaceAll(new RegExp(r"^"), "│ ")
               .replaceAll("\n", "\n│ "));
           } else {

--- a/lib/test_configuration.dart
+++ b/lib/test_configuration.dart
@@ -5,6 +5,7 @@
 library test_runner.test_configuration;
 
 import 'dart:io';
+import 'package:path/path.dart' as path;
 import 'dart_project.dart';
 
 // The classes below used as annotations to configure test files.
@@ -108,6 +109,6 @@ class TestConfiguration {
   String get testFileName {
     String absFilePath = new File(testFilePath).resolveSymbolicLinksSync();
     String absDirPath = dartProject.testDirectory.resolveSymbolicLinksSync();
-    return absFilePath.replaceFirst("$absDirPath/", "");
+    return path.relative(absFilePath, from: absDirPath).replaceAll(r'\', '/');
   }
 }


### PR DESCRIPTION
I added an emulation for the `which` command on Windows. The solution only works if we know the extension, therefore I test both `.bat` (used in dart sdk) and `.exe` (content_shell) if no extension was supplied.

I also fixed a place where we run into issues with path seperators.

I also fixed the additional line breaks in the console output.