### PR TITLE
Run specific test or directory of tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Test Runner for Dart is an open source project. It is licensed using the
 [BSD 3-Clause License](LICENSE).
 We appreciate pull requests, here are our guidelines:
 
-1. File a bug at https://github.com/dart-lang/test_runner/issues (if there
+1. File a bug at https://github.com/google/test_runner.dart/issues (if there
 isn’t one already). If your patch is going to be large it might be a good idea
 to get the discussion started early. We are happy to discuss it in a new issue
 beforehand.

--- a/bin/run_tests.dart
+++ b/bin/run_tests.dart
@@ -130,11 +130,22 @@ void runTests(
           "directory or a list of test files.\n"));
       exit(2);
     } else if (!allDartFiles && projectOrTests.length == 1) {
-      projectPath = projectOrTests[0];
+      bool isProjectPath = false;
+      try {
+        isProjectPath = DartProject.isProjectPath(projectOrTests[0]);
+      } on ArgumentError catch(e) {
+        isProjectPath = false;
+      }
+
+      if (isProjectPath) {
+        projectPath = projectOrTests[0];
+      } else {
+        testPaths = projectOrTests;
+        projectPath = "./";
+      }
     } else {
       testPaths = projectOrTests;
-      projectPath = projectOrTests[0].substring(0,
-          projectOrTests[0].lastIndexOf("test/") + 5);
+      projectPath = "./";
     }
   }
 


### PR DESCRIPTION
Fixed issue where passing a particular test file did not work (resolves https://github.com/google/test_runner.dart/issues/32)
Fixed issue where test files in subdirectories were incorrectly marked as not in the test directory (probably? resolves https://github.com/google/test_runner.dart/issues/12)
Added ability to pass a directory of test files, in which case the project path is assumed to be the current working directory
