### PR TITLE
Add configuration of default HTML file for browser tests and Dart template for VM tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .pub
 packages
+
+.idea

--- a/bin/run_tests.dart
+++ b/bin/run_tests.dart
@@ -64,6 +64,10 @@ void runTests(
                   '"auto" will use the number of processors available on the '
                   'machine. Otherwise an integer is expected.')
     String maxProcesses: "auto",
+    @Option(help: 'Provide a custom default html file for browser tests.')
+    String defaultHtmlTemplate: "",
+    @Option(help: 'Provide a custom VM Dart template file for executing VM tests.')
+    String vmDartTemplate: "",
     @Flag(abbr: 'c', help: 'Prints the output in color in a shell.')
     bool color : false,
     @Flag(abbr: 'v', help: 'Prints all tests results instead of just the '
@@ -154,7 +158,9 @@ void runTests(
   // Step 2: Check if a Dart project can be found in [projectPathUri].
 
   DartProject dartProject = new DartProject(projectPath, dartBinaries,
-                                            maxProcesses: maxParallelProcesses);
+                                            maxProcesses: maxParallelProcesses,
+                                            customDefaultHtmlPath: defaultHtmlTemplate,
+                                            customVmDartTemplatePath: vmDartTemplate);
   print("\nLooking for Dart project in \"$projectPath\"...");
   try {
     dartProject.checkProject();

--- a/lib/src/browser_test_runner.dart
+++ b/lib/src/browser_test_runner.dart
@@ -195,29 +195,3 @@ class BrowserTestRunner extends TestRunner {
            "${testFileName.replaceFirst(new RegExp(r"\.dart$"), ".html")}";
   }
 }
-
-
-/// Template of a Default HTML file for Browser unittest files that will
-/// start the tests in the Dart file written instead of the `{{test_file_name}}`
-/// placeholder.
-const String _BROWSER_TEST_HTML_FILE_TEMPLATE = '''
-<!-- Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
-for details. All rights reserved. Use of this source code is governed by a
-BSD-style license that can be found in the LICENSE file. -->
-
-<!DOCTYPE html>
-
-<html>
-  <head>
-    <title>Default Web Test HTML file</title>
-    <meta charset="utf-8" />
-    <meta name="description" content="Runs a Web test" />
-  </head>
-  <body>
-    <!-- Scripts -->
-    <script type="application/dart" src="/{{test_file_name}}"></script>
-    <script type="text/javascript"
-            src="/packages/unittest/test_controller.js"></script>
-  </body>
-</html>
-''';

--- a/lib/src/browser_test_runner_code_generator.dart
+++ b/lib/src/browser_test_runner_code_generator.dart
@@ -23,17 +23,24 @@ class BrowserTestRunnerCodeGenerator extends TestRunnerCodeGenerator {
   Future createTestHtmlFile(String testFileName, [String testHtmlFilePath]) {
     return new Future(() {
       if (testHtmlFilePath == null || testHtmlFilePath == "") {
-        // If the test does not have an associated test file we'll call the test
-        // file inside of a default HTML file.
-        return _BROWSER_TEST_HTML_FILE_TEMPLATE;
+        // If the test does not have an associated test file...
+        if (dartProject.customDefaultHtmlPath != null && dartProject.customDefaultHtmlPath.length > 0) {
+          // Use the specified default template
+          return new File(dartProject.customDefaultHtmlPath).readAsString();
+        } else {
+          // Use our predefined template
+          return _BROWSER_TEST_HTML_FILE_TEMPLATE;
+        }
       } else {
         // Custom HTML test files.
         return new File(testHtmlFilePath).readAsString();
       }
     }).then((String htmlFileString) {
       if (testHtmlFilePath == null || testHtmlFilePath == "") {
+        var pieces = testFileName.split('/');
+        var htmlInclude = pieces.last;
         htmlFileString =
-            htmlFileString.replaceAll("{{test_file_name}}", testFileName);
+            htmlFileString.replaceAll("{{test_file_name}}", htmlInclude);
       } else {
         // For custom HTML test files we add a call to
         // unittest/test_controller.js and we replace the Dart test file call by
@@ -123,7 +130,7 @@ BSD-style license that can be found in the LICENSE file. -->
   </head>
   <body>
     <!-- Scripts -->
-    <script type="application/dart" src="/{{test_file_name}}"></script>
+    <script type="application/dart" src="{{test_file_name}}"></script>
     <script type="text/javascript" src="/packages/unittest/test_controller.js"></script>
   </body>
 </html>

--- a/lib/src/dart_project.dart
+++ b/lib/src/dart_project.dart
@@ -25,6 +25,12 @@ class DartProject {
   /// Path to the root of the Dart project.
   String projectPath;
 
+  /// Custom default HTML page to run browser tests in
+  String customDefaultHtmlPath;
+
+  /// Dart template to use when generating Dart wrapper of test file
+  String customVmDartTemplatePath;
+
   Directory _testDirectory;
 
   /// The project's test folder [Directory].
@@ -41,7 +47,7 @@ class DartProject {
 
   /// Constructor. You can specify the maximum number of tests detection
   /// processes that can run in parallel with [maxProcesses].
-  DartProject(this.projectPath, this.dartBinaries, {int maxProcesses: 4})
+  DartProject(this.projectPath, this.dartBinaries, {int maxProcesses: 4, String this.customDefaultHtmlPath, String this.customVmDartTemplatePath})
       : _pool = new Pool(maxProcesses);
 
   /// Check if a Dart project can be found in [projectPath] and loads its

--- a/lib/src/vm_test_runner_code_generator.dart
+++ b/lib/src/vm_test_runner_code_generator.dart
@@ -22,6 +22,9 @@ class VmTestRunnerCodeGenerator extends TestRunnerCodeGenerator {
   Future createTestDartFile(String testFileName) {
     // Read the content fo the template Dart file.
     String dartFileString = _VM_TEST_DART_FILE_TEMPLATE;
+    if (dartProject.customVmDartTemplatePath != null && dartProject.customVmDartTemplatePath.length > 0) {
+      dartFileString = new File(dartProject.customVmDartTemplatePath).readAsStringSync();
+    }
 
     // Replaces templated values.
     dartFileString =
@@ -29,7 +32,7 @@ class VmTestRunnerCodeGenerator extends TestRunnerCodeGenerator {
     String pathDepth = testFileName.split(Platform.pathSeparator)
         .fold("", (String value, _) => "$value../");
     dartFileString =
-        dartFileString.replaceAll("{{path_depth}}", pathDepth);
+        dartFileString.replaceAll("{{test_file_import}}", pathDepth + testFileName);
 
     // Create the file (and delete it if it already exists).
     String generatedFilePath =
@@ -56,7 +59,7 @@ const String _VM_TEST_DART_FILE_TEMPLATE = '''
 library test_runner.vm_test_config;
 
 import 'package:unittest/vm_config.dart';
-import '{{path_depth}}{{test_file_name}}' as test;
+import '{{test_file_import}}' as test;
 
 /// Sets the VmConfiguration and then calls the original test file.
 void main() {


### PR DESCRIPTION
At least partially addresses https://github.com/google/test_runner.dart/issues/14
